### PR TITLE
implementing http.HandlerFunc

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,21 +15,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "<h1>Welcome to my awesome site!</h1>")
 }
 
-// func pathHandler(w http.ResponseWriter, r *http.Request) {
-// 	switch r.URL.Path {
-// 	case "/":
-// 		homeHandler(w, r)
-// 	case "/contact":
-// 		contactHandler(w, r)
-// 	default:
-// 		w.WriteHeader(http.StatusNotFound)
-// 		http.Error(w, "Page not found", http.StatusNotFound)
-// 	}
-// }
-
-type Router struct{}
-
-func (router Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func pathHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/":
 		homeHandler(w, r)
@@ -41,10 +27,24 @@ func (router Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// type Router struct{}
+
+// func (router Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// 	switch r.URL.Path {
+// 	case "/":
+// 		homeHandler(w, r)
+// 	case "/contact":
+// 		contactHandler(w, r)
+// 	default:
+// 		w.WriteHeader(http.StatusNotFound)
+// 		http.Error(w, "Page not found", http.StatusNotFound)
+// 	}
+// }
+
+// http.Handler - An Interface with the ServeHTTP method
+// http.HandlerFunc - A function type that accepts same args as ServeHTTP method. Also implements http.Handler
+
 func main() {
-	var router Router
-	// http.HandleFunc("/", pathHandler)
-	// http.HandleFunc("/contact", contactHandler)
 	fmt.Println("Starting the server on :3000...")
-	http.ListenAndServe(":3000", router)
+	http.ListenAndServe(":3000", http.HandlerFunc(pathHandler))
 }


### PR DESCRIPTION
Working through the ListenAndServe function and how we can define on of our other functions as an argument. 
In this case, passing our pathHandler function. 

Using http.HandleFunc ultimately converts its arguments into an http.Handler behind the scenes using the http.HandlerFunc type, which allows us to use our pathHandler function.